### PR TITLE
fix: remove staticcheck

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,11 +6,11 @@ on:
       - main
 
 jobs:
-  staticcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dominikh/staticcheck-action@v1.1.0
+  #staticcheck:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - uses: dominikh/staticcheck-action@v1.1.0
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Staticcheck doesn't support 1.18 yet, so don't run it